### PR TITLE
Use correct x86_64 and .framework for extension

### DIFF
--- a/addons/GodotApplePlugins/godot_apple_plugins.gdextension
+++ b/addons/GodotApplePlugins/godot_apple_plugins.gdextension
@@ -5,5 +5,5 @@ compatibility_minimum = 4.4
 
 [libraries]
 ios = "res://addons/GodotApplePlugins/bin/GodotApplePlugins.xcframework"
-macos.arm64 = "res://addons/GodotApplePlugins/bin/GodotApplePlugins.framework/GodotApplePlugins"
-macos.x86 = "res://addons/GodotApplePlugins/bin/GodotApplePlugins_x64.framework/GodotApplePlugins"
+macos.arm64 = "res://addons/GodotApplePlugins/bin/GodotApplePlugins.framework"
+macos.x86_64 = "res://addons/GodotApplePlugins/bin/GodotApplePlugins_x64.framework"


### PR DESCRIPTION
- When exporting I would get:
```sh
  WARNING: editor/export/editor_export_platform.h:252 - GDExtension: No "x86_64" library found for GDExtension: "res://addons/GodotApplePlugins/godot_apple_plugins.gdextension". Possible feature flags for your platform: pc, s3tc, macos, universal, bptc, x86_64, arm64, template, debug, template_debug, single
```

The gdextension had `x86` instead of `x86_64`.

Also, the framework path was `lib.framework/lib` instead of `lib.framework`.
