### PR TITLE
Adding new method to Fetch User Purchases for StoreKitManager

### DIFF
--- a/Sources/GodotApplePlugins/StoreKit/StoreKitManager.swift
+++ b/Sources/GodotApplePlugins/StoreKit/StoreKitManager.swift
@@ -24,6 +24,9 @@ public class StoreKitManager: RefCounted, @unchecked Sendable {
     // StoreKitStatus, error_message (empty on success)
     @Signal("status", "message") var restore_completed: SignalWithArguments<Int, String>
 
+    // StoreKitStatus, error_message (empty on success)
+    @Signal("status", "message") var refresh_completed: SignalWithArguments<Int, String>
+
     // This is only raised for verified results
     @Signal("status") var subscription_update: SignalWithArguments<StoreSubscriptionInfoStatus?>
 
@@ -252,6 +255,9 @@ public class StoreKitManager: RefCounted, @unchecked Sendable {
                 await MainActor.run {
                     handleTransaction(verificationResult)
                 }
+            }
+            await MainActor.run {
+                _ = self.refresh_completed.emit(StoreKitStatus.OK.rawValue, "")
             }
         }
     }

--- a/doc_classes/StoreKitManager.xml
+++ b/doc_classes/StoreKitManager.xml
@@ -49,6 +49,14 @@
 				                This method will raise the [signal products_request_completed] signal when the information is retrieved.
 			</description>
 		</method>
+		<method name="refresh_purchased_products">
+			<return type="void" />
+			<description>
+				Checks the user's currently owned products (entitlements) without prompting for a login (silent check).
+				                This iterates through verified entitlements and emits [signal transaction_updated] for each one.
+				                This will raise the [signal refresh_completed] signal when the check is complete.
+			</description>
+		</method>
 		<method name="restore_purchases">
 			<return type="void" />
 			<description>
@@ -81,6 +89,13 @@
 		<signal name="purchase_intent">
 			<param index="0" name="product" type="StoreProduct" />
 			<description>
+			</description>
+		</signal>
+		<signal name="refresh_completed">
+			<param index="0" name="status" type="int" />
+			<param index="1" name="error_message" type="String" />
+			<description>
+				Emitted when the refresh process completes. `arg1` is the [enum StoreKitStatus], and `arg2` is an error message if applicable.
 			</description>
 		</signal>
 		<signal name="restore_completed">


### PR DESCRIPTION
After some digging for proper managing of purchased products I noticed StoreKit2 has a nice method / property on `Transaction` to fetch all of the users active subscriptions and previously purchased non-consumable products.

**TLDR; Adding a silent restore purchases method**

https://developer.apple.com/documentation/storekit/transaction/currententitlements

PS - Sorry for formatting I can remove it if not desired, also I corrected some minor spelling mistakes ;)

@migueldeicaza 