### PR TITLE
Add ASWebAuthenticationSession class for OAuth-style authentication flow

### DIFF
--- a/Sources/GodotApplePlugins/AuthenticationServices/ASWebAuthenticationSession.swift
+++ b/Sources/GodotApplePlugins/AuthenticationServices/ASWebAuthenticationSession.swift
@@ -1,0 +1,141 @@
+//
+//  ASWebAuthenticationSession.swift
+//  GodotApplePlugins
+//
+//  Created by Dragos Daian on 01/14/26.
+//
+
+import Foundation
+import AuthenticationServices
+import SwiftGodotRuntime
+#if canImport(UIKit)
+import UIKit
+#else
+import AppKit
+#endif
+
+@Godot
+class ASWebAuthenticationSession: RefCounted, @unchecked Sendable {
+    /// Emitted when the auth flow completes successfully.
+    /// The callback URL contains the authorization code / token, depending on your provider.
+    @Signal("callback_url") var completed: SignalWithArguments<String>
+
+    /// Emitted when the auth flow fails.
+    @Signal("message") var failed: SignalWithArguments<String>
+
+    /// Emitted when the user cancels the auth flow (e.g. closes the sheet).
+    @Signal var canceled: SimpleSignal
+
+    private var session: AuthenticationServices.ASWebAuthenticationSession?
+    private var proxy: Proxy?
+
+    private final class Proxy: NSObject, ASWebAuthenticationPresentationContextProviding {
+        nonisolated override init() {
+            super.init()
+        }
+#if canImport(UIKit)
+        func presentationAnchor(for session: AuthenticationServices.ASWebAuthenticationSession) -> ASPresentationAnchor {
+            // Godot apps should have a key window. If not, return a new window (may not present correctly).
+            return UIApplication.shared.keyWindow ?? UIWindow(frame: .zero)
+        }
+#else
+        private var fallbackWindow: NSWindow?
+
+        func presentationAnchor(for session: AuthenticationServices.ASWebAuthenticationSession) -> ASPresentationAnchor {
+            if let window = NSApplication.shared.keyWindow ?? NSApplication.shared.mainWindow {
+                return window
+            }
+            // Fallback for unusual embedding cases.
+            if fallbackWindow == nil {
+                fallbackWindow = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 1, height: 1),
+                                          styleMask: [.titled],
+                                          backing: .buffered,
+                                          defer: true)
+            }
+            return fallbackWindow!
+        }
+#endif
+    }
+
+    /// Starts an OAuth-style web authentication flow.
+    ///
+    /// - Parameters:
+    ///   - auth_url: The URL to open (provider auth endpoint).
+    ///   - callback_scheme: Your app’s callback URL scheme (e.g. "mygame") or empty string to not restrict.
+    ///   - prefers_ephemeral: If true, uses an ephemeral browser session (no shared cookies).
+    ///
+    /// Returns true if the session started.
+    @Callable
+    func start(auth_url: String, callback_scheme: String, prefers_ephemeral: Bool = false) -> Bool {
+        guard let url = URL(string: auth_url) else {
+            failed.emit("Invalid auth_url")
+            return false
+        }
+
+        let scheme: String? = callback_scheme.isEmpty ? nil : callback_scheme
+
+        // Cancel any existing session to avoid overlapping flows.
+        session?.cancel()
+        session = nil
+        proxy = nil
+
+        let proxy = Proxy()
+        self.proxy = proxy
+
+        let session = AuthenticationServices.ASWebAuthenticationSession(url: url, callbackURLScheme: scheme) { [weak self] callbackURL, error in
+            guard let self else { return }
+
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                defer {
+                    self.session = nil
+                    self.proxy = nil
+                }
+
+                if let error {
+                    if let asError = error as? ASWebAuthenticationSessionError,
+                       asError.code == .canceledLogin {
+                        self.canceled.emit()
+                        return
+                    }
+                    self.failed.emit(error.localizedDescription)
+                    return
+                }
+
+                guard let callbackURL else {
+                    self.failed.emit("Missing callback URL")
+                    return
+                }
+
+                self.completed.emit(callbackURL.absoluteString)
+            }
+        }
+
+        session.presentationContextProvider = proxy
+
+        if #available(iOS 13.0, macOS 10.15, *) {
+            session.prefersEphemeralWebBrowserSession = prefers_ephemeral
+        }
+
+        self.session = session
+
+        // Must be started on the main thread (presentation).
+        if Thread.isMainThread {
+            return session.start()
+        }
+
+        var started = false
+        DispatchQueue.main.sync {
+            started = session.start()
+        }
+        return started
+    }
+
+    /// Cancels a running session.
+    @Callable
+    func cancel() {
+        session?.cancel()
+        session = nil
+        proxy = nil
+    }
+}

--- a/Sources/GodotApplePlugins/GodotApplePlugins.swift
+++ b/Sources/GodotApplePlugins/GodotApplePlugins.swift
@@ -50,7 +50,8 @@ import SwiftGodotRuntime
 
         ASAuthorizationAppleIDCredential.self,
         ASPasswordCredential.self,
-        ASAuthorizationController.self
+        ASAuthorizationController.self,
+        ASWebAuthenticationSession.self
     ],
     enums: [
         AVAudioSession.CategoryOptions.self,

--- a/doc_classes/ASWebAuthenticationSession.xml
+++ b/doc_classes/ASWebAuthenticationSession.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ASWebAuthenticationSession" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Presents a secure web-based authentication flow (OAuth) using the system browser.
+	</brief_description>
+	<description>
+		Wraps Apple's [code]ASWebAuthenticationSession[/code] so you can perform OAuth-style logins (e.g. Facebook/Google) with a callback URL.
+
+		This presents a system-controlled authentication UI and returns the callback URL when the provider redirects back to your app.
+
+		Notes:
+		- You must configure your callback URL scheme in your app (e.g. via Info.plist URL Types).
+		- Use [param prefers_ephemeral] if you want to avoid shared cookies (useful for “pick account” flows).
+
+		[codeblocks]
+		[gdscript]
+		var web_auth := ASWebAuthenticationSession.new()
+
+		func _ready():
+			web_auth.completed.connect(_on_web_auth_completed)
+			web_auth.failed.connect(_on_web_auth_failed)
+			web_auth.canceled.connect(_on_web_auth_canceled)
+
+		func login_facebook():
+			var auth_url = "https://www.facebook.com/v18.0/dialog/oauth?client_id=...&redirect_uri=mygame://oauth&response_type=code"
+			web_auth.start(auth_url, "mygame", false)
+
+		func _on_web_auth_completed(callback_url: String):
+			print("Callback URL: ", callback_url)
+			# parse 'code=' etc.
+
+		func _on_web_auth_failed(message: String):
+			push_error("Web auth failed: %s" % message)
+
+		func _on_web_auth_canceled():
+			print("User canceled")
+		[/gdscript]
+		[/codeblocks]
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="start">
+			<return type="bool" />
+			<param index="0" name="auth_url" type="String" />
+			<param index="1" name="callback_scheme" type="String" />
+			<param index="2" name="prefers_ephemeral" type="bool" />
+			<description>
+				Starts the authentication session.
+				[param auth_url] is the provider authorization URL.
+				[param callback_scheme] is your app's callback URL scheme (pass an empty string to not restrict).
+				[param prefers_ephemeral] controls whether the session uses an ephemeral browser session.
+				Returns [code]true[/code] if the session started.
+			</description>
+		</method>
+		<method name="cancel">
+			<return type="void" />
+			<description>
+				Cancels the running authentication session (if any).
+			</description>
+		</method>
+	</methods>
+	<signals>
+		<signal name="completed">
+			<param index="0" name="callback_url" type="String" />
+			<description>
+				Emitted when the authentication session completes successfully.
+				[param callback_url] is the full callback URL as a string.
+			</description>
+		</signal>
+		<signal name="failed">
+			<param index="0" name="message" type="String" />
+			<description>
+				Emitted when the authentication session fails.
+				[param message] is the localized error description.
+			</description>
+		</signal>
+		<signal name="canceled">
+			<description>
+				Emitted when the user cancels the authentication UI.
+			</description>
+		</signal>
+	</signals>
+</class>


### PR DESCRIPTION
- I want to be able to authenticate using external providers (eg. Google, Facebook). If I do so right now using OS.shell("...")... the safari browser will remain open, and I will need to manually go back to the app. In other games right now, they use the `ASWebAuthenticationSession` mechanism. This asks the user before opening ("Do you want to allow facebook.com to sign in you into the game"). At the end, they close the webview (it opens in webview) and reeturns to the game. It also returns back the token auth.