### PR TITLE
Adding more methods for saving player data to iCloud via Game Center

### DIFF
--- a/Sources/GodotApplePlugins/GameCenter/GameCenterGuide.md
+++ b/Sources/GodotApplePlugins/GameCenter/GameCenterGuide.md
@@ -157,6 +157,62 @@ local_player.fetch_items_for_identity_verification_signature(func(values: Dictio
 )
 ```
 
+# Saved Games
+
+## Handling Conflicts
+
+When multiple devices save games with the same name, conflicts can occur. You can handle these conflicts by registering a listener and implementing the resolution logic.
+
+```gdscript
+var game_center: GameCenterManager
+var local: GKLocalPlayer
+
+func _ready() -> void:
+    game_center = GameCenterManager.new()
+    local = game_center.local_player
+    
+    # Register the listener to receive conflict signals
+    local.register_listener()
+    
+    local.conflicting_saved_games.connect(_on_conflicting_saved_games)
+
+func _on_conflicting_saved_games(player: GKPlayer, conflicts: Array) -> void:
+    print("Received conflict for player: %s" % player.alias)
+    
+    # Logic to determine which data to keep (e.g., newest, highest score, or user choice)
+    # For this example, we assume we want to keep the data from the first conflicting save.
+    
+    var chosen_save = conflicts[0] as GKSavedGame
+    
+    chosen_save.load_data(func(data: PackedByteArray, error: Variant) -> void:
+        if error:
+            print("Error loading data: %s" % error)
+            return
+            
+        # Resolve the conflict using the chosen data
+        local.resolve_conflicting_saved_games(conflicts, data, func(saved_games: Array[GKSavedGame], error: Variant) -> void:
+            if error:
+                print("Error resolving conflict: %s" % error)
+            else:
+                print("Conflict resolved!")
+        )
+    )
+```
+
+## Saved Game Modifications
+
+You can also listen for modifications to saved games (e.g., from other devices).
+
+```gdscript
+func _ready() -> void:
+    # ... setup local player ...
+    local.saved_game_modified.connect(_on_saved_game_modified)
+
+func _on_saved_game_modified(player: GKPlayer, saved_game: GKSavedGame) -> void:
+    print("Saved game modified: %s" % saved_game.name)
+    # Reload data or update UI
+```
+
 # Achievements
 
 * [GKAchievement](https://developer.apple.com/documentation/gamekit/gkachievement)

--- a/doc_classes/GKLocalPlayer.xml
+++ b/doc_classes/GKLocalPlayer.xml
@@ -54,6 +54,22 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	   <signals>
+	       <signal name="conflicting_saved_games">
+	           <param index="0" name="player" type="GKPlayer" />
+	           <param index="1" name="conflicting_saved_games" type="Array" />
+	           <description>
+	               Emitted when there is a conflict between saved games. You should listen to this signal and then call [method resolve_conflicting_saved_games] with the chosen data.
+	           </description>
+	       </signal>
+	       <signal name="saved_game_modified">
+	           <param index="0" name="player" type="GKPlayer" />
+	           <param index="1" name="saved_game" type="GKSavedGame" />
+	           <description>
+	               Emitted when a saved game is modified.
+	           </description>
+	       </signal>
+	   </signals>
 	<methods>
 		<method name="delete_saved_games">
 			<return type="void" />
@@ -111,6 +127,27 @@
 				                and on error, the second parameter is not-nil and contains the error message.
 			</description>
 		</method>
+		      <method name="register_listener">
+		          <return type="void" />
+		          <description>
+		              Registers the local player listener to receive events like saved game conflicts. You typically call this in your [code]_ready()[/code] function.
+		          </description>
+		      </method>
+		      <method name="unregister_listener">
+		          <return type="void" />
+		          <description>
+		              Unregisters the local player listener.
+		          </description>
+		      </method>
+		      <method name="resolve_conflicting_saved_games">
+		          <return type="void" />
+		          <param index="0" name="conflicts" type="Array" />
+		          <param index="1" name="data" type="PackedByteArray" />
+		          <param index="2" name="callback" type="Callable" />
+		          <description>
+		              Resolves conflicting saved games using the provided data. The [code]conflicts[/code] array should contain the [GKSavedGame] objects that are in conflict (received from the [signal conflicting_saved_games]). The [code]data[/code] is the correct game data to save. The callback receives [code](Array[GKSavedGame] saved_games, Variant error)[/code].
+		          </description>
+		      </method>
 	</methods>
 	<members>
 		<member name="is_authenticated" type="bool" setter="" getter="get_is_authenticated" default="false">


### PR DESCRIPTION
# Implement GameKit Conflict Resolution and Saved Game Listener

## Description
This PR implements the necessary infrastructure in `GKLocalPlayer` to handle Game Center saved game conflicts and modifications, allowing Godot games to properly resolve data conflicts between devices.

- https://developer.apple.com/documentation/gamekit/gklocalplayerlistener
- https://developer.apple.com/documentation/gamekit/saving-the-player-s-game-data-to-an-icloud-account

## Changes

### GKLocalPlayer.swift
- **Conflict Resolution:** Implemented `resolve_conflicting_saved_games` to expose the native API to Godot.
- **Listener Implementation:** Added a nested `Proxy` class (inheriting `NSObject`, `GKLocalPlayerListener`) to bridge native delegate events to Godot signals, following the pattern used in `GKMatchMakerViewController`.
- **Signals:** Added two new signals:
    - `conflicting_saved_games(player: GKPlayer, conflicts: Array)`
    - `saved_game_modified(player: GKPlayer, saved_game: GKSavedGame)`
- **Lifecycle Management:** Added `register_listener()` and `unregister_listener()` to allow explicit control over the listener.
- **Thread Safety:** All signal emissions are dispatched to the Main Actor to ensure safe execution in the Godot environment.

### Documentation
- **API Reference:** Updated `doc_classes/GKLocalPlayer.xml` with descriptions for the new methods and signals.
- **Guide:** Updated `GameCenterGuide.md` with a new "Saved Games" section, providing code examples for handling conflicts and listening for modifications.