### PR TITLE
Expose JWS representation of StoreKit transactions

### DIFF
--- a/Sources/GodotStoreKit/StoreKitManager.swift
+++ b/Sources/GodotStoreKit/StoreKitManager.swift
@@ -140,7 +140,7 @@ public class StoreKitManager: RefCounted, @unchecked Sendable {
     private func handleTransaction(_ verificationResult: VerificationResult<Transaction>) {
         switch verificationResult {
         case .verified(let transaction):
-            let storeTransaction = StoreTransaction(transaction)
+            let storeTransaction = StoreTransaction(transaction, jws: verificationResult.jwsRepresentation)
             // Always finish the transaction if it's verified and we've received it
             // In a real app, we might want to wait until the user has unlocked content,
             // but for this binding, we'll emit the signal and finish it.
@@ -151,7 +151,7 @@ public class StoreKitManager: RefCounted, @unchecked Sendable {
                 self.transaction_updated.emit(storeTransaction)
             }
         case .unverified(let transaction, let verificationError):
-            let storeTransaction = StoreTransaction(transaction)
+            let storeTransaction = StoreTransaction(transaction, jws: verificationResult.jwsRepresentation)
             Task { @MainActor in
                 self.unverified_transaction_updated.emit(storeTransaction, VerificationError.from(verificationError).rawValue)
             }
@@ -205,7 +205,7 @@ public class StoreKitManager: RefCounted, @unchecked Sendable {
                 case .success(let verification):
                     switch verification {
                     case .verified(let transaction):
-                        let storeTransaction = StoreTransaction(transaction)
+                        let storeTransaction = StoreTransaction(transaction, jws: verification.jwsRepresentation)
                         await MainActor.run {
                             _ = self.purchase_completed.emit(storeTransaction, StoreKitStatus.OK.rawValue, "")
                         }

--- a/Sources/GodotStoreKit/StoreSubscriptionInfo.swift
+++ b/Sources/GodotStoreKit/StoreSubscriptionInfo.swift
@@ -149,9 +149,10 @@ class StoreSubscriptionInfoStatus: RefCounted, @unchecked Sendable {
     }
 
     @Export var transaction: StoreTransaction? {
-        switch status?.transaction {
+        guard let verificationResult = status?.transaction else { return nil }
+        switch verificationResult {
         case .verified(let txn):
-            return StoreTransaction(txn)
+            return StoreTransaction(txn, jws: verificationResult.jwsRepresentation)
         default:
             return nil
         }

--- a/Sources/GodotStoreKit/StoreTransaction.swift
+++ b/Sources/GodotStoreKit/StoreTransaction.swift
@@ -11,11 +11,19 @@ import StoreKit
 @Godot
 class StoreTransaction: RefCounted, @unchecked Sendable {
     var transaction: Transaction?
+    var jws: String = ""
 
-    convenience init(_ transaction: Transaction) {
+    convenience init(_ transaction: Transaction, jws: String = "") {
         self.init()
         self.transaction = transaction
+        self.jws = jws
     }
+
+    /// The JWS (JSON Web Signature) representation of the signed transaction.
+    /// Useful for server-side validation, e.g. the App Store Server API or
+    /// third-party receipt validators such as RevenueCat's `/receipts` endpoint.
+    /// Empty when the transaction was not constructed from a `VerificationResult`.
+    @Export var jws_representation: String { jws }
 
     @Export var transactionId: Int { Int(bitPattern: UInt(transaction?.id ?? 0)) }
     @Export var originalID: Int { Int(bitPattern: UInt(transaction?.originalID ?? 0)) }


### PR DESCRIPTION
## Summary

Adds a `jws_representation` property to `StoreTransaction`, exposing the signed JWS payload of a StoreKit 2 transaction to consumers.

StoreKit 2 only surfaces the signed JWS via `VerificationResult` (`VerificationResult.jwsRepresentation`). The binding currently unwraps the `VerificationResult` to a `Transaction` and discards the JWS, so there is no way for a Godot game to obtain the token needed for **server-side receipt validation** — e.g. the [App Store Server API](https://developer.apple.com/documentation/appstoreserverapi) or third-party validators such as [RevenueCat's `/receipts` endpoint](https://www.revenuecat.com/docs/api-v1).

This is the iOS equivalent of the Android purchase token, which is essential for any backend/subscription-analytics integration that isn't using a vendor SDK.

## Changes

- `StoreTransaction`: new `jws` stored property + `convenience init(_:jws:)` (defaulting to `""` for backward compatibility) + `@Export var jws_representation`.
- Thread `VerificationResult.jwsRepresentation` into `StoreTransaction` at each construction site that has a `VerificationResult`:
  - `StoreKitManager.handleTransaction` (verified + unverified `Transaction.updates`)
  - `StoreKitManager.purchase_with_options` (verified purchase result)
  - `StoreSubscriptionInfo.transaction`
- `jws_representation` is an empty string when a transaction is built without a `VerificationResult`.

No behavior change for existing consumers — the new init parameter defaults to empty and all current exports are unchanged.

## Test plan

- [x] `swift build --target GodotApplePluginsStoreKit` compiles clean.
- [ ] On-device: confirm `jws_representation` is non-empty for a verified sandbox purchase and that the JWS validates against the App Store / a receipt validator.