### PR TITLE
Add jws_representation to docs/stubs (follow-up to #35)

### DIFF
--- a/Generated/GodotApplePluginsStub/README.md
+++ b/Generated/GodotApplePluginsStub/README.md
@@ -9,8 +9,8 @@ This run used the full `doc_classes/*.xml` set.
 ## Generated Surface
 
 - Classes: 92
-- Methods: 903
-- Members: 418
+- Methods: 904
+- Members: 419
 - Signals: 79
 - Integer constants: 329
 

--- a/Generated/GodotApplePluginsStub/godot_apple_plugins_stub.c
+++ b/Generated/GodotApplePluginsStub/godot_apple_plugins_stub.c
@@ -13257,6 +13257,15 @@ static const GAPStubMethodDescriptor gap_class_88_methods[] = {
     0
 },
 {
+    "get_jws_representation",
+    "StoreTransaction.get_jws_representation",
+    GDEXTENSION_METHOD_FLAG_NORMAL,
+    1,
+    { GDEXTENSION_VARIANT_TYPE_STRING, "", GAP_PROPERTY_HINT_NONE, "", GAP_PROPERTY_USAGE_DEFAULT },
+    NULL,
+    0
+},
+{
     "get_original_id",
     "StoreTransaction.get_original_id",
     GDEXTENSION_METHOD_FLAG_NORMAL,
@@ -13323,6 +13332,12 @@ static const GAPStubPropertyDescriptor gap_class_88_properties[] = {
     { GDEXTENSION_VARIANT_TYPE_BOOL, "", GAP_PROPERTY_HINT_NONE, "", GAP_PROPERTY_USAGE_DEFAULT },
     "",
     "get_is_upgraded"
+},
+{
+    "jws_representation",
+    { GDEXTENSION_VARIANT_TYPE_STRING, "", GAP_PROPERTY_HINT_NONE, "", GAP_PROPERTY_USAGE_DEFAULT },
+    "",
+    "get_jws_representation"
 },
 {
     "original_id",
@@ -14650,9 +14665,9 @@ static const GAPStubClassDescriptor gap_classes[] = {
     "StoreTransaction",
     "RefCounted",
     gap_class_88_methods,
-    9,
+    10,
     gap_class_88_properties,
-    8,
+    9,
     NULL,
     0,
     NULL,

--- a/doc_classes/StoreTransaction.xml
+++ b/doc_classes/StoreTransaction.xml
@@ -31,6 +31,9 @@
 		<member name="is_upgraded" type="bool" setter="" getter="get_is_upgraded" default="false">
 			Whether this transaction is an upgrade of another transaction.
 		</member>
+		<member name="jws_representation" type="String" setter="" getter="get_jws_representation" default="&quot;&quot;">
+			The JWS (JSON Web Signature) representation of the signed transaction, suitable for server-side receipt validation (for example the App Store Server API or a third-party validator such as RevenueCat). Empty when the transaction was not constructed from a verification result.
+		</member>
 		<member name="original_id" type="int" setter="" getter="get_original_id" default="0">
 			The transaction identifier of the original purchase.
 		</member>


### PR DESCRIPTION
## Summary

Follow-up to #35, which added `StoreTransaction.jws_representation` in Swift only.

The non-Apple stub library and the packaged docs are generated from `doc_classes/*.xml` (via `GodotApplePluginsStubGenerator` / `make generate-stubs`), so a Swift-only export is invisible to them. As flagged by automated review on #35, a project reading `jws_representation` works against the Apple framework but reports a missing member when loaded against the Windows/Linux stub.

## Changes

- `doc_classes/StoreTransaction.xml`: add the `jws_representation` `<member>` (String, `get_jws_representation`).
- `Generated/GodotApplePluginsStub/godot_apple_plugins_stub.c` + `README.md`: regenerated via `make generate-stubs` so the combined stub registers `jws_representation` (Members 418 → 419).

No source/behavior change — this only brings the docs and non-Apple stub in line with the already-merged Swift export.

## Draft

Marked draft pending an on-device sanity check that `jws_representation` is non-empty for a verified sandbox purchase (the runtime export from #35).

## Test plan

- [x] `make generate-stubs` regenerates cleanly; stub registers `jws_representation`.
- [ ] On-device: `jws_representation` non-empty for a verified sandbox purchase and validates against a receipt validator.