### PR TITLE
Dismiss the matchmaker sheet when a match is found

### DIFF
--- a/Sources/GodotGameCenter/GKMatchMakerViewController.swift
+++ b/Sources/GodotGameCenter/GKMatchMakerViewController.swift
@@ -114,7 +114,23 @@ class GKMatchmakerViewController: RefCounted, @unchecked Sendable {
         func matchmakerViewController(
             _ viewController: GameKit.GKMatchmakerViewController, didFind match: GameKit.GKMatch
         ) {
-            base?.did_find_match.emit(GKMatch(match: match))
+            guard let base else { return }
+            // A presented view controller does not dismiss itself; the presenter has to.
+            // Without this the matchmaking sheet stays over the game after the match has
+            // started, and the player has to close it by hand — while the match, and any
+            // clock it runs, is already under way.
+            //
+            // The match itself stays out of the main-actor closure: it is task-isolated, and
+            // handing it across would be a data race the compiler is right to refuse. It is
+            // emitted where the original emitted it.
+            MainActor.assumeIsolated {
+                #if os(macOS)
+                    base.dialogController?.dismiss(viewController)
+                #else
+                    viewController.dismiss(animated: true)
+                #endif
+            }
+            base.did_find_match.emit(GKMatch(match: match))
         }
 
         func matchmakerViewController(
@@ -293,7 +309,18 @@ class GKMatchmakerViewController: RefCounted, @unchecked Sendable {
             _ viewController: GameKit.GKMatchmakerViewController,
             didFind match: GameKit.GKMatch
         ) {
+            // Same reason as `Proxy` above: found is an ending like cancelled and failed are,
+            // and it is the only one of the three that left the sheet on screen. `done()`
+            // releases the delegate, so the callback fires exactly once.
+            MainActor.assumeIsolated {
+                #if os(iOS)
+                    viewController.dismiss(animated: true)
+                #else
+                    dialogController?.dismiss(viewController)
+                #endif
+            }
             _ = self.callback.call(Variant(GKMatch(match: match)), nil)
+            done()
         }
 
         func matchmakerViewControllerWasCancelled(

--- a/Sources/GodotGameCenter/GKMatchMakerViewController.swift
+++ b/Sources/GodotGameCenter/GKMatchMakerViewController.swift
@@ -108,7 +108,17 @@ class GKMatchmakerViewController: RefCounted, @unchecked Sendable {
             _ viewController: GameKit.GKMatchmakerViewController, didFailWithError error: any Error
         ) {
             GD.print("GKMVC: didFailWithError")
-            base?.failed_with_error.emit(String(describing: error))
+            guard let base else { return }
+            // Apple requires the delegate to dismiss the controller on failure, the same as
+            // on cancellation — the turn-based controller already does; this one did not.
+            MainActor.assumeIsolated {
+                #if os(macOS)
+                    base.dialogController?.dismiss(viewController)
+                #else
+                    viewController.dismiss(animated: true)
+                #endif
+            }
+            base.failed_with_error.emit(String(describing: error))
         }
 
         func matchmakerViewController(
@@ -137,11 +147,22 @@ class GKMatchmakerViewController: RefCounted, @unchecked Sendable {
             _ viewController: GameKit.GKMatchmakerViewController,
             didFindHostedPlayers players: [GameKit.GKPlayer]
         ) {
+            guard let base else { return }
+            // A hosted match found is the same ending as `didFind` — GameKit calls this
+            // callback instead of that one when `isHosted` is set, so it needs the same
+            // dismissal.
+            MainActor.assumeIsolated {
+                #if os(macOS)
+                    base.dialogController?.dismiss(viewController)
+                #else
+                    viewController.dismiss(animated: true)
+                #endif
+            }
             let result = VariantArray()
             for player in players {
                 result.append(Variant(GKPlayer(player: player)))
             }
-            base?.did_find_hosted_players.emit(result)
+            base.did_find_hosted_players.emit(result)
         }
 
         func matchmakerViewController(
@@ -310,8 +331,8 @@ class GKMatchmakerViewController: RefCounted, @unchecked Sendable {
             didFind match: GameKit.GKMatch
         ) {
             // Same reason as `Proxy` above: found is an ending like cancelled and failed are,
-            // and it is the only one of the three that left the sheet on screen. `done()`
-            // releases the delegate, so the callback fires exactly once.
+            // and every ending dismisses the sheet. `done()` releases the delegate, so the
+            // callback fires exactly once.
             MainActor.assumeIsolated {
                 #if os(iOS)
                     viewController.dismiss(animated: true)
@@ -345,6 +366,15 @@ class GKMatchmakerViewController: RefCounted, @unchecked Sendable {
             _ source: GameKit.GKMatchmakerViewController,
             didFailWithError: (any Error)
         ) {
+            // Dismiss on failure as on cancellation, mirroring the turn-based
+            // `RequestMatchDelegate`, then answer and release the delegate.
+            MainActor.assumeIsolated {
+                #if os(iOS)
+                    source.dismiss(animated: true)
+                #else
+                    dialogController?.dismiss(source)
+                #endif
+            }
             _ = self.callback.call(nil, GKError.from(didFailWithError))
             done()
         }

--- a/Sources/GodotGameCenter/GKTurnBasedMatchmakerViewController.swift
+++ b/Sources/GodotGameCenter/GKTurnBasedMatchmakerViewController.swift
@@ -68,7 +68,14 @@ class GKTurnBasedMatchmakerViewController: RefCounted, @unchecked Sendable {
             _ viewController: GameKit.GKTurnBasedMatchmakerViewController,
             didFind match: GameKit.GKTurnBasedMatch
         ) {
-            base?.did_find_match.emit(GKTurnBasedMatch(match: match))
+            guard let base else { return }
+            // The sheet is dismissed on cancel and on error already; a found match is the
+            // third ending and was the one left on screen. The match stays outside the
+            // main-actor closure — it is task-isolated and cannot be handed across.
+            MainActor.assumeIsolated {
+                base.dismiss(viewController)
+            }
+            base.did_find_match.emit(GKTurnBasedMatch(match: match))
         }
 
         func turnBasedMatchmakerViewController(
@@ -169,7 +176,17 @@ class GKTurnBasedMatchmakerViewController: RefCounted, @unchecked Sendable {
             _ viewController: GameKit.GKTurnBasedMatchmakerViewController,
             didFind match: GameKit.GKTurnBasedMatch
         ) {
+            // As in the real-time controller: dismiss, answer, and release the delegate so the
+            // callback fires exactly once.
+            MainActor.assumeIsolated {
+                #if os(iOS)
+                    viewController.dismiss(animated: true)
+                #else
+                    dialogController?.dismiss(viewController)
+                #endif
+            }
             _ = callback.call(Variant(GKTurnBasedMatch(match: match)), nil)
+            done()
         }
 
         func turnBasedMatchmakerViewControllerWasCancelled(


### PR DESCRIPTION
## The problem

Both matchmaker view controllers leave Apple's matchmaking sheet on screen when a match is found. The real-time controller also leaves it up when matchmaking fails, and in the hosted-players path.

Per controller and delegate, before this PR:

| Controller | Delegate | cancel | error | found |
|---|---|---|---|---|
| `GKMatchmakerViewController` | `Proxy` | dismisses | does not | does not |
| `GKMatchmakerViewController` | `RequestMatchDelegate` | dismisses | does not | does not |
| `GKTurnBasedMatchmakerViewController` | `Proxy` | dismisses | dismisses | does not |
| `GKTurnBasedMatchmakerViewController` | `RequestMatchDelegate` | dismisses | dismisses | does not |

`didFindHostedPlayers` — the callback GameKit uses instead of `didFind` when `isHosted` is set — did not dismiss either.

A presented view controller does not dismiss itself, so the sheet stays over the game after the match has started. The player has to close it by hand.

Two consequences that are worse than the cosmetic one:

* If the game runs a clock, it is already running while the sheet is up. In a blitz game the player can lose time, or the whole game, before they can see the board.
* Closing the sheet by hand then fires the delegate's cancel callback, so a match that is already under way reports itself as cancelled.

## Reproducing it

Call `find_match()` on either controller, accept a match with two devices signed into Game Center, and watch the second device: `did_find_match` fires, the game starts behind Apple's sheet, and the sheet stays until it is dismissed manually.

## The fix

Dismiss on every ending — found, hosted found, cancelled, failed — on both platforms. The turn-based controller already dismissed in its error paths; the real-time one now matches it.

The two `RequestMatchDelegate` found-paths also call `done()`. Without it the callback fires twice: once for the found match, and again when the sheet is dismissed.

One detail worth flagging for review. The match conversion and the emit stay outside the `MainActor.assumeIsolated` closure. `GKMatch` is task-isolated and Swift 6 refuses to let it cross into the closure; only the dismissal needs the main actor, which matches what the cancel handlers next to it do.

## How it was found

Building a real-time multiplayer game on this plugin. The sheet stayed up over a running match with a sixty-second clock, on device, every time a match was found. Tested against `3781b9c` and rebased onto current `main`, where both files are unchanged since May.

The hosted-found and error paths were caught in review on the PR itself: the original description claimed the error handlers already dismissed, which is true of the turn-based controller and was wrongly generalised to the real-time one.
