### PR TITLE
Add StoreKitManager.request_review()

### DIFF
--- a/Sources/GodotStoreKit/StoreKitManager.swift
+++ b/Sources/GodotStoreKit/StoreKitManager.swift
@@ -280,4 +280,23 @@ public class StoreKitManager: RefCounted, @unchecked Sendable {
             }
         }
     }
+
+    /// Asks StoreKit to show the rating/review sheet. Whether it actually appears is
+    /// the system's decision (at most three times per year, and never guaranteed) --
+    /// this is a request, not a command, per Apple's documentation.
+    @Callable
+    func request_review() {
+        Task { @MainActor in
+#if canImport(UIKit)
+            guard let scene = UIApplication.shared.activeWindowScene else { return }
+            if #available(iOS 16.0, tvOS 16.0, *) {
+                AppStore.requestReview(in: scene)
+            } else {
+                SKStoreReviewController.requestReview(in: scene)
+            }
+#elseif canImport(AppKit)
+            SKStoreReviewController.requestReview()
+#endif
+        }
+    }
 }


### PR DESCRIPTION
Exposes the system rating/review sheet to GDScript, which currently has no road to it.

On iOS the call resolves the active window scene and uses `AppStore.requestReview(in:)` on 16+, falling back to `SKStoreReviewController.requestReview(in:)` on 15. On macOS it falls back to `SKStoreReviewController.requestReview()`. Whether the sheet actually appears stays the system's decision (Apple caps it at three appearances per 365 days), which is why the doc comment calls it a request rather than a command.

Verified so far: compiles for macOS and links into an iOS app build (Godot 4.7 game, xcframework built via `make split-build`); the `request_review` symbol is callable from GDScript. I have not yet observed the sheet on a device — StoreKit only shows it at its own discretion in signed builds — and will report back once our TestFlight build exercises it. No new dependencies; `import StoreKit` already covers `SKStoreReviewController`.